### PR TITLE
Fix `princing` typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "astros",
 	"type": "module",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"private": true,
 	"scripts": {
 		"dev": "astro dev --host",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -11,7 +11,7 @@
 	},
 	"header": {
 		"features": "Features",
-		"princing": "Pricing",
+		"pricing": "Pricing",
 		"blog": "Blog",
 		"contact": "Contacts",
 		"primary_button_text": "Download",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -11,7 +11,7 @@
 	},
 	"header": {
 		"features": "Funzionalità",
-		"princing": "Prezzi",
+		"pricing": "Prezzi",
 		"blog": "Blog",
 		"contact": "Contatti",
 		"primary_button_text": "Scarica",

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -15,7 +15,7 @@ export const menuitems = [
 		],
 	},
 	{
-		title: "header.princing",
+		title: "header.pricing",
 		path: "/pricing",
 	},
 	{


### PR DESCRIPTION
Hey @zanhk 👋, first things first, great work on this template ! 💪 

- fix typo in `header.princing`
- fix typo in `translation.json` for both languages. 😃

I have not idea if You bump `package.json` version by hand or it is automated. Commit with this bump can be removed if needed. 👍 